### PR TITLE
Use property instead of name because name is incorrect syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Generates the whole array of SEO settings:
 <title>My Page Title</title>
 <meta name="description" content="SEO friendly description" />
 <link rel="canonical" href="https://mysite.com/page" />
-<meta name="og:url" content="https://mysite.com/page" />
-<meta name="og:site_name" content="Site name" />
-<meta name="og:title" content="My Page Title" />
-<meta name="og:description" content="SEO friendly description" />
-<meta name="og:locale" content="en_US" />
-<meta name="og:image" content="https://mysite.com/img/og.jpg" />
+<meta property="og:url" content="https://mysite.com/page" />
+<meta property="og:site_name" content="Site name" />
+<meta property="og:title" content="My Page Title" />
+<meta property="og:description" content="SEO friendly description" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:image" content="https://mysite.com/img/og.jpg" />
 ...
 ```
 

--- a/src/Tags/SeotamicTags.php
+++ b/src/Tags/SeotamicTags.php
@@ -150,20 +150,20 @@ class SeotamicTags extends Tags
             return '';
         }
 
-        $output = "<meta name=\"og:url\" content=\"{$this->canonical()}\">";
+        $output = "<meta property=\"og:url\" content=\"{$this->canonical()}\">";
 
         if (array_key_exists('open_graph_site_name', $this->values)) {
-            $output .= "<meta name=\"og:site_name\" content=\"{$this->values['open_graph_site_name']}\">";
+            $output .= "<meta property=\"og:site_name\" content=\"{$this->values['open_graph_site_name']}\">";
         }
 
-        $output .= "<meta name=\"og:title\" content=\"{$this->social_field('open_graph_title', $this->context->raw('title'))}\">";
-        $output .= "<meta name=\"og:description\" content=\"{$this->social_field('open_graph_description', $this->description())}\">";
+        $output .= "<meta property=\"og:title\" content=\"{$this->social_field('open_graph_title', $this->context->raw('title'))}\">";
+        $output .= "<meta property=\"og:description\" content=\"{$this->social_field('open_graph_description', $this->description())}\">";
 
         // TODO: Check on multisite, here we have locale_full and site_locale
-        $output .= "<meta name=\"og:locale\" content=\"{$this->context->raw('locale_full')}\">";
+        $output .= "<meta property=\"og:locale\" content=\"{$this->context->raw('locale_full')}\">";
 
         // image
-        $output .= "<meta name=\"og:image\" content=\"{$this->social_image($image)}\">";
+        $output .= "<meta property=\"og:image\" content=\"{$this->social_image($image)}\">";
 
         return $output;
     }


### PR DESCRIPTION
Changed the "name" attribute in the metatags to a "property" attribute, as this is the correct form.

Facebook sharing debugger https://developers.facebook.com/tools/debug/ shows this error (translated from german):
The following meta tags were specified with "name" instead of "property" and are ignored until the following "property" key is specified: og:url, og:site_name, og:title, og:description, og:locale, og:image