### PR TITLE
Update web.php to fix routing errors on package update.

### DIFF
--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,3 +1,3 @@
 <?php
 
-Route::get('sitemap.xml', Cnj\Seotamic\Http\Controllers\SitemapController::class)->name('cnj.seotamic.sitemap');
+Route::get('sitemap.xml', SitemapController::class)->name('cnj.seotamic.sitemap');


### PR DESCRIPTION
Hi!

For some reason I had to change this route definition because I was getting the following error on update / install.

Apologies if this PR makes no sense in case its something on our end. Any insights are apreciated.

````
[spnefro@sd1 public_html]$ composer require cnj/seotamic
Info from https://repo.packagist.org: #StandWithUkraine
Using version ^3.0 for cnj/seotamic
./composer.json has been updated
Running composer update cnj/seotamic
> Statamic\Console\Composer\Scripts::preUpdateCmd
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading cnj/seotamic (v2.1.0 => v3.0.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Upgrading cnj/seotamic (v2.1.0 => v3.0.3): Extracting archive
Package box/spout is abandoned, you should avoid using it. No replacement was suggested.
Package fruitcake/laravel-cors is abandoned, you should avoid using it. No replacement was suggested.
Package swiftmailer/swiftmailer is abandoned, you should avoid using it. Use symfony/mailer instead.
Package ueberdosis/html-to-prosemirror is abandoned, you should avoid using it. No replacement was suggested.
Package ueberdosis/prosemirror-to-html is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   UnexpectedValueException

  Invalid route action: [Cnj\Seotamic\Http\Controllers\Cnj\Seotamic\Http\Controllers\SitemapController].

  at vendor/laravel/framework/src/Illuminate/Routing/RouteAction.php:92
     88▕      */
     89▕     protected static function makeInvokable($action)
     90▕     {
     91▕         if (! method_exists($action, '__invoke')) {
  ➜  92▕             throw new UnexpectedValueException("Invalid route action: [{$action}].");
     93▕         }
     94▕
     95▕         return $action.'@__invoke';
     96▕     }

  • `Cnj\Seotamic\Http\Controllers\Cnj\Seotamic\Http\Controllers\SitemapController` was not found: Controller class `Cnj\Seotamic\Http\Controllers\Cnj\Seotamic\Http\Controllers\SitemapController` for one of your routes was not found. Are you sure this controller exists and is imported correctly?

      +29 vendor frames
  30  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```