### PR TITLE
Add alternates to the sitemap and ignore pages blocked by robots flag

### DIFF
--- a/resources/views/sitemap.antlers.html
+++ b/resources/views/sitemap.antlers.html
@@ -4,6 +4,9 @@
     <url>
         <loc>{{ loc }}</loc>
         <lastmod>{{ lastmod }}</lastmod>
+        {{ alternates }}
+        <xhtml:link xmlns:xhtml="http://www.w3.org/1999/xhtml" rel="alternate" hreflang="{{lang}}" href="{{href}}" />
+        {{ /alternates }}
     </url>
 {{ /entries }}
 </urlset>


### PR DESCRIPTION
This pull request extends the sitemap by providing alternate versions of that page in different languages. Specified by https://developers.google.com/search/docs/specialty/international/localized-versions#sitemap

It also checks the `robots` value in seotamic_meta to exclude the page from the sitemap if it should not be indexed, this works for a single entries as well as the global flag.  